### PR TITLE
fixes connect glossary table for hub update

### DIFF
--- a/connect/300_glossary.md
+++ b/connect/300_glossary.md
@@ -4,11 +4,11 @@ name: Glossary
 
 ## Glossary
 
-| Term | Definition | Source |
- ----------- | ----------- |
-| **Conditions & Diseases** | Why a patient needs care (problem). Does not include symptoms. | Clinical experts |
-| **Treatments & Procedures** | Care needed by the patient, provided by the provider (solution). | Clinical experts |
-| **Provider** | Provider of patient care; associated with a NPI. | Health system |
-| **Specialty** | Comprised of specialty + subspecialty + area of practice. | American Medical Association + clinical experts |
-| **Location** | Physical site where care is provided to patients. | Health system |
-| **NPI** | The National Provider Identifier (NPI) is a HIPAA Administrative Simplification Standard. It is a unique 10-digit identification number for covered health care providers. | Centers for Medicare & Medicaid |
+| Term                        | Definition                                                                                                                                                                 | Source                                          |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| **Conditions & Diseases**   | Why a patient needs care (problem). Does not include symptoms.                                                                                                             | Clinical experts                                |
+| **Treatments & Procedures** | Care needed by the patient, provided by the provider (solution).                                                                                                           | Clinical experts                                |
+| **Provider**                | Provider of patient care; associated with a NPI.                                                                                                                           | Health system                                   |
+| **Specialty**               | Comprised of specialty + subspecialty + area of practice.                                                                                                                  | American Medical Association + clinical experts |
+| **Location**                | Physical site where care is provided to patients.                                                                                                                          | Health system                                   |
+| **NPI**                     | The National Provider Identifier (NPI) is a HIPAA Administrative Simplification Standard. It is a unique 10-digit identification number for covered health care providers. | Centers for Medicare & Medicaid                 |

--- a/guide/200_javascriptSdk.md
+++ b/guide/200_javascriptSdk.md
@@ -283,16 +283,16 @@ Close guide window.
 
 ```js
 window.GuideSDK.bot.setCustomVariables({
-  custom_first_name: "Radric",
-  custom_last_name: "Davis",
-  custom_account_number: "12345678",
-  custom_birth_date: "07/07/1980",
-  custom_phone_number: "770-999-0989",
-  custom_email_address: "radric@email.com",
-  custom_address_1: "123 Main Street",
-  custom_city: "Atlanta",
-  custom_state: "GA",
-  custom_zip: "30308",
+  custom_first_name: "Michael",
+  custom_last_name: "Scott",
+  custom_birth_date: "03-15-1964",
+  custom_phone_number: "555-555-5555",
+  custom_account_number: "1234567890",
+  custom_email_address: "michael.scott@dundermifflin.com",
+  custom_address_1: "42 Kellum Court",
+  custom_city: "Scranton",
+  custom_state: "PA",
+  custom_zip: "18503",
 });
 ```
 


### PR DESCRIPTION
we need to upgrade the package that renders markdown in Hub and for whatever reason the new version is having issues with this table. I updated the markdown to work on both versions so this can go in whenever.

Edit: also switched the values in the `setCustomVariables` Guide SDK docs to mirror the table below for clarity